### PR TITLE
Fix position of cards column

### DIFF
--- a/db/migrate/20240727122823_remove_position_from_cards.rb
+++ b/db/migrate/20240727122823_remove_position_from_cards.rb
@@ -1,0 +1,7 @@
+class RemovePositionFromCards < ActiveRecord::Migration[7.0]
+  def change
+    if column_exists?(:cards, :position)
+      remove_column :cards, :position
+    end
+  end
+end

--- a/db/migrate/20240727122928_add_position_to_cards.rb
+++ b/db/migrate/20240727122928_add_position_to_cards.rb
@@ -1,0 +1,5 @@
+class AddPositionToCards < ActiveRecord::Migration[7.0]
+  def change
+    add_column :cards, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_07_26_124929) do
+ActiveRecord::Schema[7.0].define(version: 2024_07_27_122928) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,8 +30,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_07_26_124929) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "due_date"
-    t.integer "position"
     t.integer "user_id"
+    t.integer "position"
     t.index ["list_id"], name: "index_cards_on_list_id"
   end
 


### PR DESCRIPTION
positionカラムの挙動がおかしかったので削除して再度作成
おそらく、タスクの移動をRailsのみで作成した時に使用したGemの影響でマイグレーションファイルを作成せずにデータにのみpositoinカラムが存在していたため